### PR TITLE
build: support cmake default dir setting with ruby 3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,11 +2,11 @@ name: Ruby
 
 on:
   push:
-    branches: 
+    branches:
       - main
 
   pull_request:
-    branches: 
+    branches:
       - main
 
 jobs:
@@ -17,6 +17,7 @@ jobs:
       matrix:
         ruby:
           - '2.7.8'
+          - '3.3.8'
 
     steps:
     - uses: actions/checkout@v4
@@ -28,7 +29,7 @@ jobs:
     - name: bundle
       run: bundle install
     - name: compile
-      run: | 
+      run: |
         cd ext/rinchi-gem/
         ruby extconf.rb && make
     - name: test

--- a/lib/rinchi-gem.rb
+++ b/lib/rinchi-gem.rb
@@ -1,4 +1,8 @@
 # frozen_string_literal: true
 
-require_relative "../ext/rinchi-gem/rinchi"
+begin
+  require_relative "../ext/rinchi-gem/rinchi"
+rescue LoadError
+  require "rinchi"
+end
 require "rinchi-gem/version"


### PR DESCRIPTION
Ruby 2.7 uses simple make "DESTDIR=" install.

Ruby 3.x adds explicit DESTDIR, sitearchdir, and sitelibdir parameters to stage compiled extensions.